### PR TITLE
feat: add Tags endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const validateApiKey = async () => {
   }
 
   return true;
-}
+};
 
 const validApiKey = await validateApiKey();
 
@@ -60,17 +60,17 @@ if (validApiKey) {
 
 The following modules of the Up API are fully supported:
 
-* [Accounts](https://developer.up.com.au/#accounts)
-* [Categories](https://developer.up.com.au/#categories)
-* [Transactions](https://developer.up.com.au/#transactions)
-* [Utility](https://developer.up.com.au/#utility_endpoints)
+- [Accounts](https://developer.up.com.au/#accounts)
+- [Categories](https://developer.up.com.au/#categories)
+- [Transactions](https://developer.up.com.au/#transactions)
+- [Utility](https://developer.up.com.au/#utility_endpoints)
+- [Tags](https://developer.up.com.au/#tags)
 
 ## Not supported yet
 
 The following modules of the Up API are not yet supported (feel free to send a PR!):
 
-* [Tags](https://developer.up.com.au/#tags)
-* [Webhooks](https://developer.up.com.au/#webhooks)
+- [Webhooks](https://developer.up.com.au/#webhooks)
 
 ## Special thanks
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "dts-bundle": "^0.7.3",
     "jest": "^26.4.2",
-    "prettier": "^2.1.2",
     "rollup": "^2.26.9",
     "rollup-plugin-typescript2": "^0.27.2",
     "ts-jest": "^26.3.0",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "access": "public"
   },
   "dependencies": {
-    "axios": "^0.20.0"
+    "axios": "^0.19.0"
   },
   "devDependencies": {
     "dts-bundle": "^0.7.3",
     "jest": "^26.4.2",
+    "prettier": "^2.1.2",
     "rollup": "^2.26.9",
     "rollup-plugin-typescript2": "^0.27.2",
     "ts-jest": "^26.3.0",

--- a/src/helper/client.ts
+++ b/src/helper/client.ts
@@ -10,7 +10,7 @@ export class UpClient {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`
+        Authorization: `Bearer ${apiKey}`,
       },
     });
   }
@@ -18,5 +18,15 @@ export class UpClient {
   public async get<T>(url: string): Promise<T> {
     const res = await this.api.get<T>(url);
     return res.data;
+  }
+
+  public async post<T>(url: string, payload: T): Promise<void> {
+    await this.api.post<T>(url, { data: payload });
+    return;
+  }
+
+  public async delete<T>(url: string, payload: T): Promise<void> {
+    await this.api.delete<T>(url, { data: { data: payload } });
+    return;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,16 @@
 import { UtilApi } from './util/api';
-import { AccountsApi } from "./accounts/api";
-import { CategoriesApi } from "./categories/api";
-import { UpClient } from "./helper/client";
-import { TransactionsApi } from "./transactions/api";
+import { AccountsApi } from './accounts/api';
+import { CategoriesApi } from './categories/api';
+import { UpClient } from './helper/client';
+import { TransactionsApi } from './transactions/api';
+import { TagsApi } from './tags/api';
 
 export class UpApi {
   public util: UtilApi;
   public accounts: AccountsApi;
   public categories: CategoriesApi;
   public transactions: TransactionsApi;
+  public tags: TagsApi;
 
   constructor(apiKey: string) {
     const api = new UpClient(apiKey);
@@ -16,6 +18,7 @@ export class UpApi {
     this.accounts = new AccountsApi(api);
     this.categories = new CategoriesApi(api);
     this.transactions = new TransactionsApi(api);
+    this.tags = new TagsApi(api);
   }
 }
 
@@ -24,5 +27,5 @@ export * from './interfaces';
 export * from './util/interfaces';
 export * from './accounts/interfaces';
 export * from './categories/interfaces';
+export * from './tags/interfaces';
 export * from './transactions/interfaces';
-

--- a/src/tags/api.ts
+++ b/src/tags/api.ts
@@ -33,12 +33,13 @@ export class TagsApi {
    * ignored.
    * @param transactionId The unique identifier for the transaction. e.g.
    * 0a3c4bdd-1de5-4b9b-bf9e-53fb0b5f2cd7
+   * @param tags The tags to add to the transaction.
    */
   public async addTagsToTransaction(
     transactionId: string,
-    data: TagInputResourceIdentifier[]
+    tags: TagInputResourceIdentifier[]
   ): Promise<void> {
-    return this.api.post(TagsApi.buildTransactionTagsPath(transactionId), data);
+    return this.api.post(TagsApi.buildTransactionTagsPath(transactionId), tags);
   }
 
   /**
@@ -46,12 +47,13 @@ export class TagsApi {
    * not associated are silently ignored.
    * @param transactionId The unique identifier for the transaction. e.g.
    * 0a3c4bdd-1de5-4b9b-bf9e-53fb0b5f2cd7
+   * @param tags The tags to remove from the transaction.
    */
   public async removeTagsFromTransaction(
     transactionId: string,
-    data: TagInputResourceIdentifier[]
+    tags: TagInputResourceIdentifier[]
   ): Promise<void> {
-    return this.api.delete(TagsApi.buildTransactionTagsPath(transactionId), data);
+    return this.api.delete(TagsApi.buildTransactionTagsPath(transactionId), tags);
   }
 
   /**

--- a/src/tags/api.ts
+++ b/src/tags/api.ts
@@ -1,0 +1,65 @@
+import { ListTagsRequest, ListTagsResponse, TagInputResourceIdentifier } from './interfaces';
+import { UpClient } from '../helper/client';
+
+const LIST_ENDPOINT = 'tags';
+const TRANSACTION_ENDPOINT = 'transactions';
+
+/**
+ * Tags are custom labels that can be associated with transactions on Up. Within
+ * the Up application, tags provide additional insight into spending. For
+ * example, you could have a "Take Away" tag that you apply to purchases from
+ * food delivery services. The Up API allows you to manage the tags associated
+ * with transactions. Each transaction may have up to 6 tags.
+ */
+export class TagsApi {
+  constructor(private api: UpClient) {}
+
+  /**
+   * Retrieve a list of all tags currently in use. The returned list is not
+   * paginated.
+   */
+  public async list(params: ListTagsRequest = {}): Promise<{ data: ListTagsResponse[] }> {
+    const urlParams = [];
+    if (params.pageSize) {
+      urlParams.push(`page[size]=${params.pageSize}`);
+    }
+
+    return this.api.get<{ data: ListTagsResponse[] }>(`${LIST_ENDPOINT}?${urlParams.join('&')}`);
+  }
+
+  /**
+   * Associates one or more tags with a specific transaction. No more than 6
+   * tags may be present on any single transaction. Duplicate tags are silently
+   * ignored.
+   * @param transactionId The unique identifier for the transaction. e.g.
+   * 0a3c4bdd-1de5-4b9b-bf9e-53fb0b5f2cd7
+   */
+  public async addTagsToTransaction(
+    transactionId: string,
+    data: TagInputResourceIdentifier[]
+  ): Promise<void> {
+    return this.api.post(TagsApi.buildTransactionTagsPath(transactionId), data);
+  }
+
+  /**
+   * Disassociates one or more tags from a specific transaction. Tags that are
+   * not associated are silently ignored.
+   * @param transactionId The unique identifier for the transaction. e.g.
+   * 0a3c4bdd-1de5-4b9b-bf9e-53fb0b5f2cd7
+   */
+  public async removeTagsFromTransaction(
+    transactionId: string,
+    data: TagInputResourceIdentifier[]
+  ): Promise<void> {
+    return this.api.delete(TagsApi.buildTransactionTagsPath(transactionId), data);
+  }
+
+  /**
+   * Build API path to access the tags for a given transaction.
+   * @param transactionId The unique identifier for the transaction. e.g.
+   * 0a3c4bdd-1de5-4b9b-bf9e-53fb0b5f2cd7
+   */
+  private static buildTransactionTagsPath(transactionId: string) {
+    return `${TRANSACTION_ENDPOINT}/${transactionId}/relationships/tags`;
+  }
+}

--- a/src/tags/interfaces.ts
+++ b/src/tags/interfaces.ts
@@ -1,0 +1,76 @@
+/**
+ * Provides information about a tag.
+ */
+export interface TagResource {
+  /**
+   * The type of this resource: `tags`
+   */
+  type: string;
+  /**
+   * The label of the tag, which also acts as the tag’s unique identifier.
+   */
+  id: string;
+  relationships: {
+    transactions: {
+      links?: {
+        /**
+         * The link to retrieve the related resource(s) in this relationship.
+         */
+        related: string;
+      };
+    };
+  };
+}
+
+/**
+ * Uniquely identifies a single tag in the API.
+ */
+export interface TagInputResourceIdentifier {
+  /**
+   * The type of this resource: `tags`
+   */
+  type: string;
+  /**
+   * The label of the tag, which also acts as the tag’s unique identifier.
+   */
+  id: string;
+}
+
+export interface ListTagsRequest {
+  /** The number of records to return in each page. e.g. ?page[size]=30 */
+  pageSize?: number;
+}
+
+/**
+ * Successful response to get all tags. This returns a paginated list of
+ * tags, which can be scrolled by following the `prev` and `next` links if
+ * present.
+ */
+export interface ListTagsResponse {
+  /**
+   * The list of tags returned in this response.
+   */
+  data: TagResource;
+  links: {
+    /**
+     * The link to the previous page in the results. If this value is `null`
+     * there is no previous page.
+     */
+    prev: string | null;
+    /**
+     * The link to the next page in the results. If this value is `null`
+     * there is no next page.
+     */
+    next: string | null;
+  };
+}
+
+/**
+ * Request to add or remove tags associated with a transaction.
+ */
+export interface UpdateTransactionTagsRequest {
+  /**
+   * The tags to add to or remove from the transaction.
+   */
+  data: TagInputResourceIdentifier;
+}


### PR DESCRIPTION
Hi there!

I added support for the Tags endpoints. Tried to follow your formatting and layout but let me know if I need to fix anything.

Had to bump down Axios due to a known issue with `axios.delete()` as described at https://github.com/axios/axios/issues/3220

It says it should be fixed in the next version so can update for 0.21?

Possibly for a separate PR, but would be good to have some linting / auto-formatters to ensure consistency. Was using prettier for this with the following config:
```
{
  "trailingComma": "es5",
  "tabWidth": 2,
  "semi": true,
  "singleQuote": true,
  "printWidth": 100
}

```