### PR TITLE
feat: extract endpoint variables into separate constants file

### DIFF
--- a/src/accounts/api.ts
+++ b/src/accounts/api.ts
@@ -4,7 +4,7 @@ import {
   ListAccountsRequest,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-import { ENDPOINTS } from 'src/constants';
+import { ENDPOINTS } from '../constants';
 
 /**
  * Accounts represent the underlying store used to track balances and the transactions

--- a/src/accounts/api.ts
+++ b/src/accounts/api.ts
@@ -4,8 +4,7 @@ import {
   ListAccountsRequest,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-
-const ENDPOINT = 'accounts';
+import { ENDPOINTS } from 'src/constants';
 
 /**
  * Accounts represent the underlying store used to track balances and the transactions
@@ -29,7 +28,7 @@ export class AccountsApi {
     }
 
     return this.api.get<ListAccountResponse>(
-      `${ENDPOINT}?${urlParams.join('&')}`
+      `${ENDPOINTS.ACCOUNTS}?${urlParams.join('&')}`
     );
   }
 
@@ -38,6 +37,8 @@ export class AccountsApi {
    * @param accountId The unique identifier for the account. e.g. e7a729f0-aaa7-4d6a-b231-f794c0155e1d
    */
   public async retrieve(accountId: string): Promise<{ data: AccountResource }> {
-    return this.api.get<{ data: AccountResource }>(`${ENDPOINT}/${accountId}`);
+    return this.api.get<{ data: AccountResource }>(
+      `${ENDPOINTS.ACCOUNTS}/${accountId}`
+    );
   }
 }

--- a/src/categories/api.ts
+++ b/src/categories/api.ts
@@ -1,6 +1,6 @@
 import { CategoryResource, ListCategoriesRequest } from './interfaces';
 import { UpClient } from '../helper/client';
-import { ENDPOINTS } from 'src/constants';
+import { ENDPOINTS } from '../constants';
 
 /**
  * Categories enable understanding where your money goes by driving powerful insights in Up.

--- a/src/categories/api.ts
+++ b/src/categories/api.ts
@@ -1,7 +1,6 @@
 import { CategoryResource, ListCategoriesRequest } from './interfaces';
 import { UpClient } from '../helper/client';
-
-const ENDPOINT = 'categories';
+import { ENDPOINTS } from 'src/constants';
 
 /**
  * Categories enable understanding where your money goes by driving powerful insights in Up.
@@ -24,7 +23,7 @@ export class CategoriesApi {
     }
 
     return this.api.get<{ data: CategoryResource[] }>(
-      `${ENDPOINT}?${urlParams.join('&')}`
+      `${ENDPOINTS.CATEGORIES}?${urlParams.join('&')}`
     );
   }
 
@@ -36,7 +35,7 @@ export class CategoriesApi {
     categoryId: string
   ): Promise<{ data: CategoryResource }> {
     return this.api.get<{ data: CategoryResource }>(
-      `${ENDPOINT}/${categoryId}`
+      `${ENDPOINTS.CATEGORIES}/${categoryId}`
     );
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Up API base URL.
+ */
+export const BASE_URL = 'https://api.up.com.au/api/v1/';
+
+/**
+ * Up API endpoint routes.
+ */
+export const ENDPOINTS = {
+  ACCOUNTS: 'accounts',
+  CATEGORIES: 'categories',
+  TAGS: 'tags',
+  TRANSACTIONS: 'transactions',
+  WEBHOOKS: 'webhooks',
+  UTIL: 'util',
+};

--- a/src/helper/client.ts
+++ b/src/helper/client.ts
@@ -1,11 +1,12 @@
 import axios, { AxiosInstance } from 'axios';
+import { BASE_URL } from 'src/constants';
 
 export class UpClient {
   private api: AxiosInstance;
 
   constructor(apiKey: string) {
     this.api = axios.create({
-      baseURL: 'https://api.up.com.au/api/v1/',
+      baseURL: BASE_URL,
       timeout: 5000,
       headers: {
         Accept: 'application/json',

--- a/src/helper/client.ts
+++ b/src/helper/client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { BASE_URL } from 'src/constants';
+import { BASE_URL } from '../constants';
 
 export class UpClient {
   private api: AxiosInstance;

--- a/src/tags/api.ts
+++ b/src/tags/api.ts
@@ -4,7 +4,7 @@ import {
   TagInputResourceIdentifier,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-import { ENDPOINTS } from 'src/constants';
+import { ENDPOINTS } from '../constants';
 
 /**
  * Tags are custom labels that can be associated with transactions on Up. Within

--- a/src/tags/api.ts
+++ b/src/tags/api.ts
@@ -4,9 +4,7 @@ import {
   TagInputResourceIdentifier,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-
-const LIST_ENDPOINT = 'tags';
-const TRANSACTION_ENDPOINT = 'transactions';
+import { ENDPOINTS } from 'src/constants';
 
 /**
  * Tags are custom labels that can be associated with transactions on Up. Within
@@ -31,7 +29,7 @@ export class TagsApi {
     }
 
     return this.api.get<{ data: ListTagsResponse[] }>(
-      `${LIST_ENDPOINT}?${urlParams.join('&')}`
+      `${ENDPOINTS.TAGS}?${urlParams.join('&')}`
     );
   }
 
@@ -73,6 +71,6 @@ export class TagsApi {
    * 0a3c4bdd-1de5-4b9b-bf9e-53fb0b5f2cd7
    */
   private static buildTransactionTagsPath(transactionId: string) {
-    return `${TRANSACTION_ENDPOINT}/${transactionId}/relationships/tags`;
+    return `${ENDPOINTS.TRANSACTIONS}/${transactionId}/relationships/tags`;
   }
 }

--- a/src/transactions/api.ts
+++ b/src/transactions/api.ts
@@ -4,7 +4,7 @@ import {
   TransactionResource,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-import { ENDPOINTS } from 'src/constants';
+import { ENDPOINTS } from '../constants';
 
 /**
  * Transactions represent the movement of money into and out of an account. They have many

--- a/src/transactions/api.ts
+++ b/src/transactions/api.ts
@@ -4,8 +4,7 @@ import {
   TransactionResource,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-
-const ENDPOINT = 'transactions';
+import { ENDPOINTS } from 'src/constants';
 
 /**
  * Transactions represent the movement of money into and out of an account. They have many
@@ -28,7 +27,7 @@ export class TransactionsApi {
     const urlParams = this.createUrlParams(params);
 
     return this.api.get<ListTransactionsResponse>(
-      `${ENDPOINT}?${urlParams.join('&')}`
+      `${ENDPOINTS.TRANSACTIONS}?${urlParams.join('&')}`
     );
   }
 
@@ -40,7 +39,7 @@ export class TransactionsApi {
     transactionId: string
   ): Promise<{ data: TransactionResource }> {
     return this.api.get<{ data: TransactionResource }>(
-      `${ENDPOINT}/${transactionId}`
+      `${ENDPOINTS.TRANSACTIONS}/${transactionId}`
     );
   }
 
@@ -58,7 +57,7 @@ export class TransactionsApi {
     const urlParams = this.createUrlParams(params);
 
     return this.api.get<ListTransactionsResponse>(
-      `/accounts/${accountId}/${ENDPOINT}?${urlParams.join('&')}`
+      `/accounts/${accountId}/${ENDPOINTS.TRANSACTIONS}?${urlParams.join('&')}`
     );
   }
 

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -1,7 +1,6 @@
 import { Pong } from './interfaces';
 import { UpClient } from '../helper/client';
-
-const ENDPOINT = 'util';
+import { ENDPOINTS } from 'src/constants';
 
 /**
  * Some endpoints exist not to expose data, but to test the API itself.
@@ -17,6 +16,6 @@ export class UtilApi {
    * On failure an HTTP 401 error response is returned.
    */
   public async ping(): Promise<Pong> {
-    return this.api.get<Pong>(`${ENDPOINT}/ping`);
+    return this.api.get<Pong>(`${ENDPOINTS.UTIL}/ping`);
   }
 }

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -1,6 +1,6 @@
 import { Pong } from './interfaces';
 import { UpClient } from '../helper/client';
-import { ENDPOINTS } from 'src/constants';
+import { ENDPOINTS } from '../constants';
 
 /**
  * Some endpoints exist not to expose data, but to test the API itself.

--- a/src/webhooks/api.ts
+++ b/src/webhooks/api.ts
@@ -7,7 +7,7 @@ import {
   WebhookResource,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-import { ENDPOINTS } from 'src/constants';
+import { ENDPOINTS } from '../constants';
 
 /**
  * Webhooks provide a mechanism for a configured URL to receive events when

--- a/src/webhooks/api.ts
+++ b/src/webhooks/api.ts
@@ -7,8 +7,7 @@ import {
   WebhookResource,
 } from './interfaces';
 import { UpClient } from '../helper/client';
-
-const ENDPOINT = 'webhooks';
+import { ENDPOINTS } from 'src/constants';
 
 /**
  * Webhooks provide a mechanism for a configured URL to receive events when
@@ -31,7 +30,7 @@ export class WebhookApi {
     }
 
     return this.api.get<{ data: ListWebhooksResponse[] }>(
-      `${ENDPOINT}?${urlParams.join('&')}`
+      `${ENDPOINTS.WEBHOOKS}?${urlParams.join('&')}`
     );
   }
 
@@ -55,7 +54,7 @@ export class WebhookApi {
       },
     };
     return this.api.post<WebhookInputResource, CreateWebhookResponse>(
-      ENDPOINT,
+      ENDPOINTS.WEBHOOKS,
       data
     );
   }
@@ -66,7 +65,7 @@ export class WebhookApi {
    * a3f1e92b-b790-42cf-afe7-6f4efad9fa9d
    */
   public async retrieve(id: string): Promise<WebhookResource> {
-    return this.api.get<WebhookResource>(`${ENDPOINT}/${id}`);
+    return this.api.get<WebhookResource>(`${ENDPOINTS.WEBHOOKS}/${id}`);
   }
 
   /**
@@ -76,7 +75,7 @@ export class WebhookApi {
    * a3f1e92b-b790-42cf-afe7-6f4efad9fa9d
    */
   public async delete(id: string): Promise<void> {
-    return this.api.delete(`${ENDPOINT}/${id}`);
+    return this.api.delete(`${ENDPOINTS.WEBHOOKS}/${id}`);
   }
 
   /**
@@ -87,6 +86,8 @@ export class WebhookApi {
    * a3f1e92b-b790-42cf-afe7-6f4efad9fa9d
    */
   public async ping(id: string): Promise<WebhookEventResource> {
-    return this.api.post<void, WebhookEventResource>(`${ENDPOINT}/${id}/ping`);
+    return this.api.post<void, WebhookEventResource>(
+      `${ENDPOINTS.WEBHOOKS}/${id}/ping`
+    );
   }
 }


### PR DESCRIPTION
Small change to extract the endpoint strings out to a constants file since there was already some reuse happening in the Tags API.  Moved the base URL into the constants as well as it will be used in the pagination #5 util function.