### PR TITLE
fix: return types on list tags + webhooks

### DIFF
--- a/src/tags/api.ts
+++ b/src/tags/api.ts
@@ -20,15 +20,13 @@ export class TagsApi {
    * Retrieve a list of all tags currently in use. The returned list is not
    * paginated.
    */
-  public async list(
-    params: ListTagsRequest = {}
-  ): Promise<{ data: ListTagsResponse[] }> {
+  public async list(params: ListTagsRequest = {}): Promise<ListTagsResponse> {
     const urlParams = [];
     if (params.pageSize) {
       urlParams.push(`page[size]=${params.pageSize}`);
     }
 
-    return this.api.get<{ data: ListTagsResponse[] }>(
+    return this.api.get<ListTagsResponse>(
       `${ENDPOINTS.TAGS}?${urlParams.join('&')}`
     );
   }

--- a/src/webhooks/api.ts
+++ b/src/webhooks/api.ts
@@ -23,13 +23,13 @@ export class WebhookApi {
    */
   public async list(
     params: ListWebhooksRequest = {}
-  ): Promise<{ data: ListWebhooksResponse[] }> {
+  ): Promise<ListWebhooksResponse> {
     const urlParams = [];
     if (params.pageSize) {
       urlParams.push(`page[size]=${params.pageSize}`);
     }
 
-    return this.api.get<{ data: ListWebhooksResponse[] }>(
+    return this.api.get<ListWebhooksResponse>(
       `${ENDPOINTS.WEBHOOKS}?${urlParams.join('&')}`
     );
   }


### PR DESCRIPTION
small error in the return type for listing tags + webhooks