### PR TITLE
Extract common relationship object and fix incorrect/missing relationships

### DIFF
--- a/src/accounts/interfaces.ts
+++ b/src/accounts/interfaces.ts
@@ -1,4 +1,4 @@
-import { MoneyObject, PaginationLinks } from '../interfaces';
+import { MoneyObject, PaginationLinks, Relationship } from '../interfaces';
 
 export interface ListAccountsRequest {
   /** The number of records to return in each page. e.g. ?page[size]=30 */
@@ -26,10 +26,7 @@ export interface AccountResource {
     createdAt: string;
   };
   relationships: {
-    links?: {
-      /** The link to retrieve the related resource(s) in this relationship. */
-      related: string;
-    };
+    transactions: Relationship<undefined>;
   };
   links: {
     /** The canonical link to this resource within the API. */

--- a/src/categories/interfaces.ts
+++ b/src/categories/interfaces.ts
@@ -1,4 +1,4 @@
-import { Relationship } from '../interfaces';
+import { Relationship, RelationshipData } from '../interfaces';
 
 export interface ListCategoriesRequest {
   /**
@@ -19,20 +19,8 @@ export interface CategoryResource {
     name: string;
   };
   relationships: {
-    parent: {
-      data: null | Relationship;
-      links?: {
-        /** The link to retrieve the related resource(s) in this relationship. */
-        related: string;
-      };
-    };
-    children: {
-      data: Relationship[];
-      links?: {
-        /** The link to retrieve the related resource(s) in this relationship. */
-        related: string;
-      };
-    };
+    parent: Relationship<null | RelationshipData<'categories'>>;
+    children: Relationship<Array<RelationshipData<'categories'>>>;
   };
   links: {
     /** The canonical link to this resource within the API. */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,11 +14,19 @@ export interface MoneyObject {
   valueInBaseUnits: number;
 }
 
-export interface Relationship {
+export interface RelationshipData<RelationshipType extends string> {
   /** The type of this resource */
-  type: string;
+  type: RelationshipType;
   /** The unique identifier of the resource within its type. */
   id: string;
+}
+
+export interface Relationship<TRelationshipData> {
+  data: TRelationshipData;
+  links?: {
+    /** The link to retrieve the related resource(s) in this relationship. */
+    related: string;
+  };
 }
 
 export interface PaginationLinks {

--- a/src/tags/interfaces.ts
+++ b/src/tags/interfaces.ts
@@ -1,3 +1,5 @@
+import { Relationship } from '../interfaces';
+
 /**
  * Provides information about a tag.
  */
@@ -11,14 +13,7 @@ export interface TagResource {
    */
   id: string;
   relationships: {
-    transactions: {
-      links?: {
-        /**
-         * The link to retrieve the related resource(s) in this relationship.
-         */
-        related: string;
-      };
-    };
+    transactions: Relationship<undefined>;
   };
 }
 

--- a/src/transactions/interfaces.ts
+++ b/src/transactions/interfaces.ts
@@ -1,4 +1,9 @@
-import { MoneyObject, PaginationLinks, Relationship } from '../interfaces';
+import {
+  MoneyObject,
+  PaginationLinks,
+  Relationship,
+  RelationshipData,
+} from '../interfaces';
 
 export interface ListTransactionRequest {
   /** The number of records to return in each page. e.g. ?page[size]=30 */
@@ -116,34 +121,11 @@ export interface TransactionResource {
     createdAt: string;
   };
   relationships: {
-    account: {
-      data: Relationship;
-      links?: {
-        /** The link to retrieve the related resource(s) in this relationship. */
-        related: string;
-      };
-    };
-    category: {
-      data: null | Relationship;
-      links?: {
-        /** The link to retrieve the related resource(s) in this relationship. */
-        related: string;
-      };
-    };
-    parentCategory: {
-      data: null | Relationship;
-      links?: {
-        /** The link to retrieve the related resource(s) in this relationship. */
-        related: string;
-      };
-    };
-    tags: {
-      data: Relationship[];
-      links?: {
-        /** The link to retrieve the related resource(s) in this relationship. */
-        related: string;
-      };
-    };
+    account: Relationship<RelationshipData<'accounts'>>;
+    transferAccount: Relationship<null | RelationshipData<'accounts'>>;
+    category: Relationship<null | RelationshipData<'categories'>>;
+    parentCategory: Relationship<null | RelationshipData<'categories'>>;
+    tags: Relationship<Array<RelationshipData<'tags'>>>;
   };
   links: {
     /** The canonical link to this resource within the API. */

--- a/src/webhooks/interfaces.ts
+++ b/src/webhooks/interfaces.ts
@@ -1,3 +1,5 @@
+import { Relationship, RelationshipData } from '../interfaces';
+
 /**
  * Provides information about a webhook.
  */
@@ -41,14 +43,7 @@ export interface WebhookResource {
     createdAt: string;
   };
   relationships: {
-    logs: {
-      links?: {
-        /**
-         * The link to retrieve the related resource(s) in this relationship.
-         */
-        related: string;
-      };
-    };
+    logs: Relationship<undefined>;
   };
   links?: {
     /**
@@ -157,42 +152,8 @@ export interface WebhookEventResource {
     createdAt: string;
   };
   relationships: {
-    webhook: {
-      data: {
-        /**
-         * The type of this resource: `webhooks`
-         */
-        type: string;
-        /**
-         * The unique identifier of the resource within its type.
-         */
-        id: string;
-      };
-      links?: {
-        /**
-         * The link to retrieve the related resource(s) in this relationship.
-         */
-        related: string;
-      };
-    };
-    transaction?: {
-      data: {
-        /**
-         * The type of this resource: `transactions`
-         */
-        type: string;
-        /**
-         * The unique identifier of the resource within its type.
-         */
-        id: string;
-      };
-      links?: {
-        /**
-         * The link to retrieve the related resource(s) in this relationship.
-         */
-        related: string;
-      };
-    };
+    webhook: Relationship<RelationshipData<'webhooks'>>;
+    transaction?: Relationship<RelationshipData<'transactions'>>;
   };
 }
 
@@ -271,16 +232,7 @@ export interface WebhookDeliveryLogResource {
   };
   relationships: {
     webhookEvent: {
-      data: {
-        /**
-         * The type of this resource: `webhook-events`
-         */
-        type: string;
-        /**
-         * The unique identifier of the resource within its type.
-         */
-        id: string;
-      };
+      data: RelationshipData<'webhook-events'>;
     };
   };
 }


### PR DESCRIPTION
- Updated Relationship to take a type for the 'data' key, and added new RelationshipData type which takes the 'type' value (typically a string)
  - This will make relationship data types more strict and reflect the API
- Fixed Account `translations` relationship
- Added Transaction `transferAccount` relationship (added to API as part of https://github.com/up-banking/api/issues/66)