### PR TITLE
Adding gettable functions for links

### DIFF
--- a/src/accounts/interfaces.ts
+++ b/src/accounts/interfaces.ts
@@ -37,5 +37,5 @@ export interface AccountResource {
 export interface ListAccountResponse {
   /** The list of accounts returned in this response. */
   data: AccountResource[];
-  links: PaginationLinks;
+  links: PaginationLinks<ListAccountResponse>;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,11 +29,11 @@ export interface Relationship<TRelationshipData> {
   };
 }
 
-export interface PaginationLinks {
+export interface PaginationLinks<ReturnType> {
   /** The link to the previous page in the results. If this value is null there is no previous page. */
-  prev: string | null;
+  prev: () => Promise<ReturnType> | null;
   /** The link to the next page in the results. If this value is null there is no next page. */
-  next: string | null;
+  next: () => Promise<ReturnType> | null;
 }
 
 export interface UpApiError {

--- a/src/tags/interfaces.ts
+++ b/src/tags/interfaces.ts
@@ -45,7 +45,7 @@ export interface ListTagsResponse {
   /**
    * The list of tags returned in this response.
    */
-  data: TagResource;
+  data: TagResource[];
   links: {
     /**
      * The link to the previous page in the results. If this value is `null`

--- a/src/tags/interfaces.ts
+++ b/src/tags/interfaces.ts
@@ -1,4 +1,4 @@
-import { Relationship } from '../interfaces';
+import { Relationship, PaginationLinks } from '../interfaces';
 
 /**
  * Provides information about a tag.
@@ -46,18 +46,7 @@ export interface ListTagsResponse {
    * The list of tags returned in this response.
    */
   data: TagResource[];
-  links: {
-    /**
-     * The link to the previous page in the results. If this value is `null`
-     * there is no previous page.
-     */
-    prev: string | null;
-    /**
-     * The link to the next page in the results. If this value is `null`
-     * there is no next page.
-     */
-    next: string | null;
-  };
+  links: PaginationLinks<ListTagsResponse>;
 }
 
 /**

--- a/src/transactions/interfaces.ts
+++ b/src/transactions/interfaces.ts
@@ -136,5 +136,5 @@ export interface TransactionResource {
 export interface ListTransactionsResponse {
   /** The list of transactions returned in this response. */
   data: TransactionResource[];
-  links: PaginationLinks;
+  links: PaginationLinks<ListTransactionsResponse>;
 }

--- a/src/webhooks/interfaces.ts
+++ b/src/webhooks/interfaces.ts
@@ -1,4 +1,4 @@
-import { Relationship, RelationshipData } from '../interfaces';
+import { Relationship, RelationshipData, PaginationLinks } from '../interfaces';
 
 /**
  * Provides information about a webhook.
@@ -68,18 +68,7 @@ export interface ListWebhooksResponse {
    * The list of webhooks returned in this response.
    */
   data: WebhookResource[];
-  links: {
-    /**
-     * The link to the previous page in the results. If this value is `null`
-     * there is no previous page.
-     */
-    prev: string | null;
-    /**
-     * The link to the next page in the results. If this value is `null`
-     * there is no next page.
-     */
-    next: string | null;
-  };
+  links: PaginationLinks<ListWebhooksResponse>;
 }
 
 /**
@@ -247,16 +236,5 @@ export interface ListWebhookDeliveryLogsResponse {
    * The list of delivery logs returned in this response.
    */
   data: WebhookDeliveryLogResource[];
-  links: {
-    /**
-     * The link to the previous page in the results. If this value is `null`
-     * there is no previous page.
-     */
-    prev: string | null;
-    /**
-     * The link to the next page in the results. If this value is `null`
-     * there is no next page.
-     */
-    next: string | null;
-  };
+  links: PaginationLinks<ListWebhookDeliveryLogsResponse>;
 }


### PR DESCRIPTION
Added pre-processing step in checking if link strings are available for the next pagination.

If there are valid URLs for the next and prev page, then change the URLs to functions for the user to be able to call to get the next/previous page