### PR TITLE
fix: Relationship interfaces related as optional

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface Relationship<TRelationshipData> {
   data: TRelationshipData;
   links?: {
     /** The link to retrieve the related resource(s) in this relationship. */
-    related: string;
+    related?: string;
   };
 }
 


### PR DESCRIPTION
Fixing a type mismatch I encountered with some JSON responses of listed transactions where some links were given as `{ related: undefined }` not matching `{ related: string }`.